### PR TITLE
Add support for multiple API endpoints

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -47,7 +47,7 @@ const App = () => {
           following: following.statusText === 'OK' ? following.data : null,
           starred: starred.statusText === 'OK' ? starred.data : null,
         };
-      }))
+      }), err => console.log(err))
       .then(data => {
         // Add an entry for forks
         const results = {
@@ -56,7 +56,8 @@ const App = () => {
         };
 
         console.log(results);
-      });
+      }, err => console.log(err))
+      .catch(err => console.log(err));
   }
 
   const sendUsername=(e)=>{

--- a/src/App.js
+++ b/src/App.js
@@ -11,8 +11,52 @@ const App = () => {
   }
 
   const getDetails=()=>{
-    axios.get(`https://api.github.com/users/${username}/repos`)
-      .then(data=>console.log(data))
+    // URLs to be used for different API endpoints
+    const reposUrl = `https://api.github.com/users/${username}/repos`,
+          gistsUrl = `https://api.github.com/users/${username}/gists`,
+          followersUrl = `https://api.github.com/users/${username}/followers`,
+          followingUrl = `https://api.github.com/users/${username}/following`,
+          starredUrl = `https://api.github.com/users/${username}/starred`;
+
+    /**
+     * The API returns atmost 30 entries by default unless the
+     * 'per_page' GET parameter is specified, which can be a
+     * 100 at maximum. Multiple calls for each page are required
+     * to fetch all entries. */
+    const requests = [
+      axios.get(reposUrl, { params: { per_page: 100 } }),
+      axios.get(gistsUrl, { params: { per_page: 100 } }),
+      axios.get(followersUrl, { params: { per_page: 100 } }),
+      axios.get(followingUrl, { params: { per_page: 100 } }),
+      axios.get(starredUrl, { params: { per_page: 100 } })
+    ];
+
+    axios.all(requests)
+      .then(axios.spread((...responses) => {
+        const repos = responses[0],
+              gists = responses[1],
+              followers = responses[2],
+              following = responses[3],
+              starred = responses[4];
+
+        return {
+          username,
+          repos: repos.statusText === 'OK' ? repos.data : null,
+          gists: gists.statusText === 'OK' ? gists.data : null,
+          followers: followers.statusText === 'OK' ? followers.data : null,
+          following: following.statusText === 'OK' ? following.data : null,
+          starred: starred.statusText === 'OK' ? starred.data : null,
+        };
+      }))
+      .then(data => {
+        // Add an entry for forks
+        const results = {
+          ...data,
+          forks: data.repos.filter(repo => repo.fork)
+        };
+
+        console.log(results);
+      });
   }
 
   const sendUsername=(e)=>{

--- a/src/App.js
+++ b/src/App.js
@@ -39,7 +39,7 @@ const App = () => {
               following = responses[3],
               starred = responses[4];
 
-        return {
+        const data = {
           username,
           repos: repos.statusText === 'OK' ? repos.data : null,
           gists: gists.statusText === 'OK' ? gists.data : null,
@@ -47,16 +47,9 @@ const App = () => {
           following: following.statusText === 'OK' ? following.data : null,
           starred: starred.statusText === 'OK' ? starred.data : null,
         };
-      }), err => console.log(err))
-      .then(data => {
-        // Add an entry for forks
-        const results = {
-          ...data,
-          forks: data.repos.filter(repo => repo.fork)
-        };
 
-        console.log(results);
-      }, err => console.log(err))
+        console.log(data);
+      }), err => console.log(err))
       .catch(err => console.log(err));
   }
 


### PR DESCRIPTION
Closes #7: **Add support for more API endpoints**
This version supports the following endpoints:
- `/users/:username/repos`
- `/users/:username/gists`
- `/users/:username/followers`
- `/users/:username/following`
- `/users/:username/starred`

~Additionally, the forked repositories are filtered into a separate array.~

_Sample response object:_
``` js
{
    "username": "paramsiddharth", // The entered username
    "repos": [repo1, repo2, ...], // An array of repo objects
    "gists": [gist1, gist2, ...],
    "followers": [follower1, follower2, ...],
    "following": [user1, user2, ...],
    "starred": [repo1, repo2, ...]
    // "forks": [fork1, fork2, ...] REMOVED
}
```

In case of a failed request, the corresponding attribute is set to `null`.
``` js
    ...
    "repos": null, // Failed request
    ...
```

I chained a `.catch(...)` at the end of the request chain to properly log other network-related errors to the prompt.