### PR TITLE
Added Pagination Support

### DIFF
--- a/src/services/GitHub.js
+++ b/src/services/GitHub.js
@@ -8,7 +8,9 @@ import axios from 'axios';
  * the getAll argument in the getDetails function. */
 const TOO_MANY_PAGES = 3;
 const PER_PAGE = 100;
+const API_URL = 'https://api.github.com';
 
+// All endpoints
 const endpoints = [
 	'repos',
 	'gists',
@@ -17,13 +19,15 @@ const endpoints = [
 	'starred'
 ];
 
+// Get a page from a particular endpoint
 const getEndpoint = async (username, endpoint, pageNumber = 1, perPage = PER_PAGE) => {
 	// URL for the API endpoint
-	const url = `https://api.github.com/users/${username}/${endpoint}?per_page=${perPage}&page=${pageNumber}`;
+	const url = `${API_URL}/users/${username}/${endpoint}?per_page=${perPage}&page=${pageNumber}`;
 	const resp = await axios.get(url);
 	return resp.data.length > 0 ? resp.data : null;
 };
 
+// Get the data object for a user
 const getDetails = async (username, getAll = false) => {
 	/**
 	 * The API returns atmost 30 entries by default unless the
@@ -33,22 +37,24 @@ const getDetails = async (username, getAll = false) => {
 
 	// Initiate each call from page 1
 	let endpointPages = {};
-	let results = { username };
+	let results = { username },
+		resultArray = [];
 	for (let ep of endpoints) {
 		endpointPages[ep] = 1;
 		results[ep] = [];
+		resultArray.push([ep, []]);
 	}
 
-	// Build data object
-	for (const ep of endpoints) {
+	// Build data array
+	resultArray = await Promise.all(resultArray.map(async ([ep, arr]) => {
 		let newData;
 		while (true) {
 			newData = await getEndpoint(username, ep, endpointPages[ep]);
-			//console.log(ep, await newData);
+			//console.log(ep, newData);
 			if (newData !== null) {
-				results[ep] = [
-					...results[ep],
-					...(await newData)
+				arr = [
+					...arr,
+					...newData
 				];
 			} else
 				break;
@@ -56,22 +62,22 @@ const getDetails = async (username, getAll = false) => {
 				break;
 			endpointPages[ep]++;
 		}
-	};
+		
+		return [ep, arr];
+	}));
 
-	//console.log(await results);
+	// Convert to object
+	for (let [ep, arr] of resultArray) {
+		if (arr.length > 0)
+			results[ep] = arr;
+		else
+			results[ep] = null;
+	}
 
-	return new Promise(async (res) => {
-		let response = await results;
-
-		// Convert each empty array to null
-		for (let key in response) {
-			if (response[key].length < 1)
-				response[key] = null;
-		}
-		return res(response);
-	});
+	return new Promise(async (res) => res(await results));
 };
 
+// Exported object
 const api = {
 	endpoints,
 	getEndpoint,

--- a/src/services/GitHub.js
+++ b/src/services/GitHub.js
@@ -1,47 +1,81 @@
 import axios from 'axios';
 
-const api = {
-	getDetails: (username) => {
-		// URLs to be used for different API endpoints
-		const reposUrl = `https://api.github.com/users/${username}/repos`,
-		gistsUrl = `https://api.github.com/users/${username}/gists`,
-		followersUrl = `https://api.github.com/users/${username}/followers`,
-		followingUrl = `https://api.github.com/users/${username}/following`,
-		starredUrl = `https://api.github.com/users/${username}/starred`;
+/**
+ * 3 pages comprise ~300 records. Retrieving such a
+ * huge number for each endpoint would not be feasible by
+ * the application and may lead to exceeding the API's rate
+ * limit. This may be overridden by passing true to
+ * the getAll argument in the getDetails function. */
+const TOO_MANY_PAGES = 3;
+const PER_PAGE = 100;
 
-		/**
-		 * The API returns atmost 30 entries by default unless the
-		 * 'per_page' GET parameter is specified, which can be a
-		 * 100 at maximum. Multiple calls for each page are required
-		 * to fetch all entries. */
-		const requests = [
-			axios.get(reposUrl, { params: { per_page: 100 } }),
-			axios.get(gistsUrl, { params: { per_page: 100 } }),
-			axios.get(followersUrl, { params: { per_page: 100 } }),
-			axios.get(followingUrl, { params: { per_page: 100 } }),
-			axios.get(starredUrl, { params: { per_page: 100 } })
-		];
+const endpoints = [
+	'repos',
+	'gists',
+	'followers',
+	'following',
+	'starred'
+];
 
-		return axios.all(requests)
-			.then(axios.spread((...responses) => {
-				const repos = responses[0],
-						gists = responses[1],
-						followers = responses[2],
-						following = responses[3],
-						starred = responses[4];
+const getEndpoint = async (username, endpoint, pageNumber = 1, perPage = PER_PAGE) => {
+	// URL for the API endpoint
+	const url = `https://api.github.com/users/${username}/${endpoint}?per_page=${perPage}&page=${pageNumber}`;
+	const resp = await axios.get(url);
+	return resp.data.length > 0 ? resp.data : null;
+};
 
-				const data = {
-					username,
-					repos: repos.statusText === 'OK' ? repos.data : null,
-					gists: gists.statusText === 'OK' ? gists.data : null,
-					followers: followers.statusText === 'OK' ? followers.data : null,
-					following: following.statusText === 'OK' ? following.data : null,
-					starred: starred.statusText === 'OK' ? starred.data : null,
-				};
+const getDetails = async (username, getAll = false) => {
+	/**
+	 * The API returns atmost 30 entries by default unless the
+	 * 'per_page' GET parameter is specified, which can be a
+	 * 100 at maximum. Multiple calls for each page are required
+	 * to fetch all entries. */
 
-				return data;
-			}), err => console.log(err))
+	// Initiate each call from page 1
+	let endpointPages = {};
+	let results = { username };
+	for (let ep of endpoints) {
+		endpointPages[ep] = 1;
+		results[ep] = [];
 	}
+
+	// Build data object
+	for (const ep of endpoints) {
+		let newData;
+		while (true) {
+			newData = await getEndpoint(username, ep, endpointPages[ep]);
+			//console.log(ep, await newData);
+			if (newData !== null) {
+				results[ep] = [
+					...results[ep],
+					...(await newData)
+				];
+			} else
+				break;
+			if ((endpointPages[ep] === TOO_MANY_PAGES && !getAll) || newData.length < PER_PAGE)
+				break;
+			endpointPages[ep]++;
+		}
+	};
+
+	//console.log(await results);
+
+	return new Promise(async (res) => {
+		let response = await results;
+
+		// Convert each empty array to null
+		for (let key in response) {
+			if (response[key].length < 1)
+				response[key] = null;
+		}
+		return res(response);
+	});
+};
+
+const api = {
+	endpoints,
+	getEndpoint,
+	getDetails
 };
 
 export default api;


### PR DESCRIPTION
# Related Issue
- Resolves #18: **Add Pagination Support**

# Proposed Changes
- Use repeated API calls using `axios` to get complete data i. e. Beyond 100 records from the API.
- To avoid the rate-limit margin, the `getDetails` function would return only a maximum of 3 pages by default. That can be overridden by passing `true` to the second argument of `getDetails`. This would be the job of the person who designs the visualizations to decide.
  ``` js
  ...
  // Get the data object for a user
  const getDetails = async (username, getAll = false) => {
  ...
  ```
  Why only 3 pages by default? Assuming each of the 5 endpoints have more than 3 pages to send. Since each page has 100 records, 5 × 3 × 100 = 1500 records will have to be fetched and parsed, which would easily cross the rate-limiting and would be resource-intensive.

# Additional Info
- The schema of returned data has not been modified.
- The API service still uses simultaneous API calls by using Promises instead of a for loop to iterate through each endpoint.
  It is around 3 times faster, and the performance remains the same for endpoints that don't require pagination i. e. That contain only one page.
  ``` js
  ...
  // Build data array
  resultArray = await Promise.all(resultArray.map(async ([ep, arr]) => {
    let newData;
  ...
  ```

# Checklist
- [ ] Tests
- [ ] Translations
- [ ] Documentation

# Screenshots
The interface remains the same and hasn't been affected in any manner.
