### PR TITLE
remove of the word test compare.js

### DIFF
--- a/src/components/Compare.js
+++ b/src/components/Compare.js
@@ -148,7 +148,7 @@ const Compare =()=>{
 												?
 													<tr>
 														<td>Followers</td>
-														<td>{info1.followers.length} <span className="text-success">&emsp;+test{Math.abs(info1.followers.length-info2.followers.length)}<i>&uarr;</i></span></td>
+														<td>{info1.followers.length} <span className="text-success">&emsp;+{Math.abs(info1.followers.length-info2.followers.length)}<i>&uarr;</i></span></td>
 														<td>{info2.followers.length}</td>
 													</tr>
 												:


### PR DESCRIPTION
# Related Issue
- issues #67 

# Additional Info
- there was a test word in the master branch.
- When comparing two users.

- line Followers  
- line 152 (compare.js)

# Checklist
- [ ] Tests
- [ ] Translations
- [ ] Documentation
- [X] Fix - Correction

# Screenshots
Original
![image](https://user-images.githubusercontent.com/38507456/107513557-ae6d2b80-6ba8-11eb-96d4-ca1319d994bf.png)

Updated
![image](https://user-images.githubusercontent.com/38507456/107513734-eecca980-6ba8-11eb-9d9b-60610158c2cc.png)

